### PR TITLE
ci: auto deploy stats on change

### DIFF
--- a/.github/workflows/deploy-stats.yml
+++ b/.github/workflows/deploy-stats.yml
@@ -1,0 +1,44 @@
+name: Deploy Stats Component
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "stats/**"
+      - ".github/workflows/deploy-stats.yml"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: deployment-stats
+
+    steps:
+      - name: Deploy to VM via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/stats/carbon-aware-ai-agents
+
+            echo "Updating repository..."
+            git fetch origin main
+            git reset --hard origin/main
+
+            cd stats
+
+            echo "Updating dependencies..."
+            /home/ubuntu/.local/bin/uv pip install -r requirements.txt
+
+            echo "Updating systemd service..."
+            sudo cp deploy/stats.service /etc/systemd/system/stats.service
+            sudo systemctl daemon-reload
+
+            echo "Restarting stats service..."
+            sudo systemctl enable stats
+            sudo systemctl restart stats
+
+            echo "Deployment successful!"

--- a/stats/deploy/DEPLOYMENT.md
+++ b/stats/deploy/DEPLOYMENT.md
@@ -1,0 +1,9 @@
+# Stats Component Deployment
+
+The Stats component enjoys a standalone deployment on a dedicated VPS (separate
+from the UI and Scheduler).
+
+- Github Actions
+- Uses `appleboy/ssh-action@v1` to deploy over SSH
+- Process runs as `systemd` service
+- Uses `uv` to manage the Python environment and dependencies

--- a/stats/deploy/stats.service
+++ b/stats/deploy/stats.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Stats API Service
+After=network.target
+
+[Service]
+User=ubuntu
+Group=ubuntu
+WorkingDirectory=/opt/stats/carbon-aware-ai-agents/stats
+ExecStart=/home/ubuntu/.local/bin/uv run app.py
+Restart=always
+Environment=STATS_HOST=0.0.0.0
+Environment=STATS_PORT=5000
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Uses `appleboy/ssh-action@v1` to deploy over SSH
- Process runs as `systemd` service
- Uses `uv` to manage the Python environment and dependencies